### PR TITLE
Quotes are good.

### DIFF
--- a/nginx-redirects/templates/site.conf
+++ b/nginx-redirects/templates/site.conf
@@ -5,7 +5,7 @@ server {
         server_name                     {{ host }};
 
 {% for rule in data.rules %}
-        rewrite ^{{rule.location}} {{rule.redirect}} last;
+        rewrite "^{{rule.location}}" {{rule.redirect}} last;
 {% endfor %}
         rewrite ^.* {{data.fallback}} last;
 }


### PR DESCRIPTION
Regexes contain NASTY CHARACTERS which will call the config parser
BAD NAMES and make it cry. Surround the regex with QUOTES to stop
the nastiness.
