### PR TITLE
Start supervisor when it's installed.

### DIFF
--- a/supervisor/tasks/main.yml
+++ b/supervisor/tasks/main.yml
@@ -2,4 +2,5 @@
 
 - name: Install supervisor
   apt: name=supervisor state=present
+  notify: restart supervisor
   tags: [supervisor]


### PR DESCRIPTION
If you try to reload the config when it's not running, it
errors out with an obscure file not found error.
