### PR TITLE
DFBnc role improvements.

### DIFF
--- a/dfbnc/defaults/main.yml
+++ b/dfbnc/defaults/main.yml
@@ -4,3 +4,4 @@ dfbnc_user: bouncer
 dfbnc_dir: /home/{{ dfbnc_user }}/dfbnc
 dfbnc_listenhosts: 0.0.0.0:+33262
 dfbnc_ssl_dn: CN={{ inventory_hostname }},DC=dfbnc,DC=github,DC=com
+dfbnc_version: HEAD

--- a/dfbnc/tasks/main.yml
+++ b/dfbnc/tasks/main.yml
@@ -4,13 +4,12 @@
   apt: pkg=ant
   tags: [packages,dfbnc-dependencies,dfbnc]
 
-  # TODO: This always does a remote submodule update which
-  #       is wrong, and makes the step show as changed.
 - include: ../../shared/deploy-git-project.yml
   vars:
     repo: https://github.com/ShaneMcC/DFBnc.git
     user: "{{ dfbnc_user }}"
     dest: "{{ dfbnc_dir }}/src"
+    version: "{{ dfbnc_version }}"
   tags: [dfbnc]
 
 - name: build dfbnc
@@ -20,8 +19,8 @@
     LANG: en_US.UTF-8
     LC_CTYPE: en_US.UTF-8
   command: chdir={{ dfbnc_dir }}/src
-           creates={{ dfbnc_dir }}/src/dist/dfbnc.jar
            ant jar
+  when: git_clone.changed
   tags: [dfbnc-setup,dfbnc]
 
 - name: create config directory
@@ -62,4 +61,3 @@
             mode=0600
   when: dfbnc_keystore_create.changed
   tags: [dfbnc-setup,dfbnc-config,dfbnc]
-

--- a/shared/deploy-git-project.yml
+++ b/shared/deploy-git-project.yml
@@ -10,4 +10,5 @@
   git: accept_hostkey=yes
        dest={{ dest }}
        repo={{ repo }}
-
+       version={{ version | default(HEAD) }}
+  register: git_clone


### PR DESCRIPTION
- Allow specifying a version to checkout, instead of HEAD.
- Build when the checkout is changed, not just once.
